### PR TITLE
Updates `allowKeywords` to `true` to allow Promises

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -207,7 +207,7 @@ rules:
   dot-notation:
     - 2
     -
-      allowKeywords: false
+      allowKeywords: true
       allowPattern: ''
 
   # Enforces use of === and !== over == and !=.


### PR DESCRIPTION
Updates `allowKeywords` to `true` to allow Promises. Promises use `catch` for errors, but setting `allowKeywords` to `false` means `.catch` cannot be used because it's a keyword from a try/catch block. With this update, codebases using this linting file can fully support promises.

Follows update in https://github.com/cfpb/cfgov-refresh/pull/2334
## Changes
- Updates `allowKeywords` to `true`.
## Review
- @wpears 
- @ascott1 
- @Scotchester 
- @mistergone 
