### PR TITLE
Add open source project template script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Capital Framework is our modular front end framework. New projects should start 
 
 ## Tools
 
+- [Open source project template](https://github.com/cfpb/open-source-project-template)
 - [Browser testing checklist](browser-checklist.md)
 - [ESLint file](.eslintrc)
 - [gitignore sample](.gitignore)

--- a/open-source-template.sh
+++ b/open-source-template.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+url="https://raw.githubusercontent.com/CFPB/open-source-project-template/master"
+
+root_files=(
+  ".gitattributes"
+  ".gitignore"
+  "CHANGELOG.md"
+  "CONTRIBUTING.md"
+  "INSTALL.md"
+  "LICENSE"
+  "README.md"
+  "TERMS.md"
+)
+
+gh_files=(
+  "ISSUE_TEMPLATE.md"
+  "PULL_REQUEST_TEMPLATE.md"
+)
+
+echo "creating .github directory"
+
+mkdir -p .github
+
+echo "downloading files"
+
+for file in "${root_files[@]}"; do
+  if [ ! -f "./${file}" ]; then
+    curl -so "./${file}" "${url}/${file}"
+  else
+    echo "${file} already exists, skipping"
+  fi
+done
+
+for file in "${gh_files[@]}"; do
+  if [ ! -f "./${file}" ]; then
+    curl -so ".github/${file}" "${url}/.github/${file}"
+  else
+    echo ".github/${file} already exists, skipping"
+  fi
+done
+
+echo "download complete"


### PR DESCRIPTION
This moves the open source project template script to this repo, as discussed in [open-source-project-template/pull/22](https://github.com/cfpb/open-source-project-template/pull/22#issuecomment-295805323)