### PR TITLE
Update standards to account for IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+## 2017-07-14
+
+- Updated to reflect lack of scripting support in IE 8
+
 ## 2016-08-26
 
 - Added a starter guide to building atomically.

--- a/browser-checklist.md
+++ b/browser-checklist.md
@@ -6,9 +6,9 @@
 - [ ] IE11
 - [ ] IE10
 - [ ] IE9
-- [ ] IE8
+- [ ] IE8 - No Javascript
 - [ ] Opera
-- [ ] iOS 8
+- [ ] Mobile Safari
 - [ ] Android 4.0+
 - [ ] Chrome for Android
 - [ ] Blackberry Bold

--- a/browser-checklist.md
+++ b/browser-checklist.md
@@ -6,7 +6,7 @@
 - [ ] IE11
 - [ ] IE10
 - [ ] IE9
-- [ ] IE8 - No Javascript
+- [ ] IE8 *
 - [ ] Opera
 - [ ] Mobile Safari
 - [ ] Android 4.0+
@@ -23,3 +23,5 @@
 - [ ] Is useable without CSS
 - [ ] Is useable without JS
 - [ ] Flexible from small to large screens
+
+* JavaScript support is not required, but essential content should be readable.

--- a/javascript.md
+++ b/javascript.md
@@ -605,7 +605,7 @@ ruleOfThree(4, 2, 6);
 
 ## Polyfills
 
-Where possible use the native browser implementation and include [a polyfill that provides that behavior][27] for unsupported browsers. This makes the code easier to work with and less involved in hackery to make things just work.
+Where possible use the native browser implementation and include [a polyfill that provides that behavior][27] for unsupported browsers. This makes the code easier to work with and less involved in hackery to make things just work, the exception being Internet Explorer 8. Although we continue to support IE8, we do not support scripted interactions and rely instead on progressive enhancement to provide IE8 users with a functioning experience.
 
 If you can't patch a piece of functionality with a polyfill, then [wrap all uses of the patching code][28] in a globally available method that is accessible from everywhere in the application.
 

--- a/javascript.md
+++ b/javascript.md
@@ -605,7 +605,9 @@ ruleOfThree(4, 2, 6);
 
 ## Polyfills
 
-Where possible use the native browser implementation and include [a polyfill that provides that behavior][27] for unsupported browsers. This makes the code easier to work with and less involved in hackery to make things just work, the exception being Internet Explorer 8. Although we continue to support IE8, we do not support scripted interactions and rely instead on progressive enhancement to provide IE8 users with a functioning experience.
+Where possible use the native browser implementation and include [a polyfill that provides that behavior][27] for unsupported browsers. This makes the code easier to work with and less involved in hackery to make things just work.
+
+Although we continue to support IE8, we do not support scripted interactions and rely instead on progressive enhancement to provide IE8 users with a functioning experience.
 
 If you can't patch a piece of functionality with a polyfill, then [wrap all uses of the patching code][28] in a globally available method that is accessible from everywhere in the application.
 


### PR DESCRIPTION
We haven't supported scripted interaction in IE8 since the relaunch. Documenting this fact here for future contributors and updating the browser checklist to match.

## Review

- @cfarm 
- @sebworks 
- @anselmbradford 
- @ascott1 

[Preview this PR without the whitespace changes](?w=0)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
