### PR TITLE
Add Python linting and version-testing standards

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,15 +1,16 @@
 [flake8]
 ignore = 
+    # Allow assigning lambda expressions
     E731,
+    # Allow line breaks after binary operators
     W503,
 
-exclude = 
+exclude =
+    # Some of this are excluded for speed of directory traversal. Not all of 
+    # them have Python files we wish to ignore.
     .git,
     .tox,
     __pycache__,
     gulp,
-    requirements,
     node_modules,
-    site,
-    */jinja2,
     */migrations/*.py,

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+ignore = 
+    E731,
+    W503,
+
+exclude = 
+    .git,
+    .tox,
+    __pycache__,
+    gulp,
+    requirements,
+    node_modules,
+    site,
+    */jinja2,
+    */migrations/*.py,

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+include_trailing_comma=1
+multi_line_output=3
+skip=.tox,migrations
+not_skip=__init__.py
+use_parentheses=1
+known_django=django
+known_future_library=future,six
+known_third_party=mock
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A guide for the development team at the [CFPB](https://cfpb.github.io/).
 - [CSS/Less standards](standards/css.md)
 - [JavaScript standards](standards/javascript.md)
 - [Markup standards](standards/markup.md)
+- [Python standards](standards/python.md)
 
 ## Guides
 

--- a/standards/python.md
+++ b/standards/python.md
@@ -1,0 +1,50 @@
+# Python Guide
+
+1. [Linting](#linting)
+1. [Imports](#imports)
+3. [Python versions](#python-versions)
+
+## Linting
+
+All of our Python code should match the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/) and the [Django coding style guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/). 
+
+We follow [PEP8's line length](https://www.python.org/dev/peps/pep-0008/#maximum-line-length) instead of Django's for consistency with our other development standards. We follow [Django's recommended import ordering in Django projects](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#imports).
+
+For linting we recommend [flake8](http://flake8.pycqa.org/en/latest/), and provide a [sample flake8 configuration](../.flake8).
+Exceptions to PEP8 are found in our , and include:
+
+- `E731`, we allow assignment of `lambda` expressions
+- `W503`, we allow line breaks after binary operators
+
+On the whole, generated python files like Django migrations can be safely ignored. 
+
+Both the flake8 and isort configurations can go into a `tox.ini` file under `[flake8]` and `[isort]` headers respectively.
+
+It is highly recommended to configure flake8 linting in your editor of choice to use the configuration file above or one provided in the project you're working on.
+
+## Imports
+
+See [Imports in PEP8](https://www.python.org/dev/peps/pep-0008/#imports) and [Imports in Django Coding Style](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#imports).
+
+We use [isort](https://github.com/timothycrosley/isort) to lint imports to comply with both style guidelines, and provide a [sample isort configuration](../.isort.cfg). This configuration attempts to enforce the following conventions:
+
+- Multiple-line `from` imports become grouped within parenthesis with one imported name per-line and a trailing comma for the last imported name.
+- Generated Python files like Django migrations can be safely ignored. 
+- Consider `six` to be equivelent to `__future__` imports.
+- Django imports are included as their own section between the standard library and third-party imports.
+- For Wagtail-specific projects like [cfgov-refresh](https://github.com/cfpb/cfgov-refresh), Wagtail imports are included as their own section between Django and third-party imports.
+
+## Python versions
+
+As we transition from Python 2.7 to Python 3 it is highly recommended to test against both Python 2.7 and Python 3.6. 
+
+We recommend using [tox](https://tox.readthedocs.io/en/latest/) for matrix testing, and provide a [sample tox configuration](../tox.ini) that tests against Python 2.7 and 3.6 (and Django versions 1.8-1.11).
+
+For writing code that is Python 2 and 3-compatible, please see the [Python Porting HOWTO](https://docs.python.org/3/howto/pyporting.html) and the [Django Porting to Python3](https://docs.djangoproject.com/en/1.11/topics/python3/). In particular, we prefer to:
+
+- [Use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection)
+- Use absolute imports (`from __future__ import absolute_import`)
+- Use the `print()` function instead of the `print` statement (`from __future__ import print_function`)
+- Use unicode literals (`from __future__ import unicode_literals`), and the corresponding Django `python_2_unicode_compatible` (`from django.utils.encoding import python_2_unicode_compatible`)
+- Use Python 3 division wherein dividing `int`s results in a `float` (`from __future__ import division`)
+- Capture exceptions using the `as` keyword (`except Exception as exc`)

--- a/standards/python.md
+++ b/standards/python.md
@@ -11,14 +11,14 @@ All of our Python code should match the [PEP8 style guide](https://www.python.or
 We follow [PEP8's line length](https://www.python.org/dev/peps/pep-0008/#maximum-line-length) instead of Django's for consistency with our other development standards. We follow [Django's recommended import ordering in Django projects](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#imports).
 
 For linting we recommend [flake8](http://flake8.pycqa.org/en/latest/), and provide a [sample flake8 configuration](../.flake8).
-Exceptions to PEP8 are found in our , and include:
+Exceptions to PEP8 are found in that [sample flake8 configuration](../.flake8), and include:
 
 - `E731`, we allow assignment of `lambda` expressions
 - `W503`, we allow line breaks after binary operators
 
-On the whole, generated python files like Django migrations can be safely ignored. 
+On the whole, generated Python files like Django migrations can be safely ignored. 
 
-Both the flake8 and isort configurations can go into a `tox.ini` file under `[flake8]` and `[isort]` headers respectively.
+The flake8 and configuration can go into a `tox.ini` file under a `[flake8]` header.
 
 It is highly recommended to configure flake8 linting in your editor of choice to use the configuration file above or one provided in the project you're working on.
 
@@ -29,22 +29,23 @@ See [Imports in PEP8](https://www.python.org/dev/peps/pep-0008/#imports) and [Im
 We use [isort](https://github.com/timothycrosley/isort) to lint imports to comply with both style guidelines, and provide a [sample isort configuration](../.isort.cfg). This configuration attempts to enforce the following conventions:
 
 - Multiple-line `from` imports become grouped within parenthesis with one imported name per-line and a trailing comma for the last imported name.
-- Generated Python files like Django migrations can be safely ignored. 
-- Consider `six` to be equivelent to `__future__` imports.
+- Consider `six` to be equivalent to `__future__` imports.
 - Django imports are included as their own section between the standard library and third-party imports.
 - For Wagtail-specific projects like [cfgov-refresh](https://github.com/cfpb/cfgov-refresh), Wagtail imports are included as their own section between Django and third-party imports.
+
+The isort configuration can go into a `tox.ini` file under an `[isort]` header.
 
 ## Python versions
 
 As we transition from Python 2.7 to Python 3 it is highly recommended to test against both Python 2.7 and Python 3.6. 
 
-We recommend using [tox](https://tox.readthedocs.io/en/latest/) for matrix testing, and provide a [sample tox configuration](../tox.ini) that tests against Python 2.7 and 3.6 (and Django versions 1.8-1.11).
+We recommend using [tox](https://tox.readthedocs.io/en/latest/) for matrix testing, and provide a [sample tox configuration](../tox.ini) that tests against Python 2.7 and 3.6 and Django LTS versions 1.8 and 1.11.
 
 For writing code that is Python 2 and 3-compatible, please see the [Python Porting HOWTO](https://docs.python.org/3/howto/pyporting.html) and the [Django Porting to Python3](https://docs.djangoproject.com/en/1.11/topics/python3/). In particular, we prefer to:
 
 - [Use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection)
 - Use absolute imports (`from __future__ import absolute_import`)
 - Use the `print()` function instead of the `print` statement (`from __future__ import print_function`)
-- Use unicode literals (`from __future__ import unicode_literals`), and the corresponding Django `python_2_unicode_compatible` (`from django.utils.encoding import python_2_unicode_compatible`)
+- Use unicode literals (`from __future__ import unicode_literals`), and [the corresponding Django `python_2_unicode_compatible`](https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.encoding.python_2_unicode_compatible) (`from django.utils.encoding import python_2_unicode_compatible`)
 - Use Python 3 division wherein dividing `int`s results in a `float` (`from __future__ import division`)
 - Capture exceptions using the `as` keyword (`except Exception as exc`)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+skipsdist=True
+envlist=lint,py{27,36}-dj{18,19,110,111}
+
+[testenv]
+install_command=pip install -e ".[testing]" -U {opts} {packages}
+commands=
+    coverage erase
+    coverage run {envbindir}/django-admin.py test {posargs}
+
+basepython=
+    py27: python2.7
+    py36: python3.6
+
+deps=
+    dj18: Django>=1.8,<1.9
+    dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<1.12
+
+[testenv:lint]
+basepython=python3.6
+deps=flake8>=2.2.0
+commands=
+    flake8 .
+    isort --check-only --diff --recursive satellite

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{27,36}-dj{18,19,110,111}
+envlist=lint,py{27,36}-dj{18,111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -14,13 +14,13 @@ basepython=
 
 deps=
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
-    dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<1.12
 
 [testenv:lint]
 basepython=python3.6
-deps=flake8>=2.2.0
+deps=
+    flake8>=2.2.0
+    isort>=4.2.15
 commands=
     flake8 .
-    isort --check-only --diff --recursive satellite
+    isort --check-only --diff --recursive .


### PR DESCRIPTION
This PR adds a sample flake8, isort, and tox configuration for Python linting and testing against Python 2 and Python 3. It also starts documenting these three topics in a [Python standards file](https://github.com/cfpb/development/blob/7c98e98ed3425ce20f1ed6f79684671dd77f6671/standards/python.md).

I'm looking to include all of this in a Django app boilerplate to be used next week, so I'd love thoughts and feedback on this. 

The isort configuration corresponds to [my proposal in cfgov-refresh](https://github.com/cfpb/cfgov-refresh/pull/3602), and whatever decision is made around it here I will reflect in that PR.

The flake8 configuration is based on cfgov-refresh as well.
