### PR TITLE
allowBlockStart to true in eslint lines-around-comment rule.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -760,7 +760,7 @@ rules:
       afterBlockComment: false
       beforeLineComment: false
       afterLineComment: false
-      allowBlockStart: false
+      allowBlockStart: true
       allowBlockEnd: false
 
   # Require or disallow an empty line between class members.


### PR DESCRIPTION
## Changes

- `allowBlockStart` to `true` in eslint `lines-around-comment` rule.