### PR TITLE
Add optional-JS for IE9

### DIFF
--- a/tools/browser-checklist.md
+++ b/tools/browser-checklist.md
@@ -5,7 +5,7 @@
 - [ ] Firefox
 - [ ] IE11
 - [ ] IE10
-- [ ] IE9
+- [ ] IE9 *
 - [ ] IE8 *
 - [ ] Opera
 - [ ] Mobile Safari


### PR DESCRIPTION
## Changes

- Adds asterisk to IE9, which now doesn't need to support JS, per https://github.com/cfpb/cfgov-refresh/pull/3693
