### PR TITLE
Modifying `experimentalObjectRestSpread` because it's reached TC39 stage 4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@ parserOptions:
     globalReturn: false
     impliedStrict: true
     jsx: true
-    experimentalObjectRestSpread: false
+    experimentalObjectRestSpread: true
 
 parser: espree
 


### PR DESCRIPTION
Modifying `experimentalObjectRestSpread` because it's reached TC39 stage 4

## Changes

- Modifying `experimentalObjectRestSpread` because it's reached TC39 stage 4 and thus is no longer experimental.  https://github.com/tc39/proposal-object-rest-spread


## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
