### PR TITLE
Using Travis to upload to PyPI automatically

### DIFF
--- a/guides/pypi.md
+++ b/guides/pypi.md
@@ -1,6 +1,6 @@
 # Publishing Python packages to PyPI
 
-PyPI - the Python Package Index - is a repository of software for the Python programming language. The production instance of PyPI lives at https://pypi.python.org/pypi. A pre-production instance of a newer interface to PyPI can currently be found at https://pypi.org/.
+PyPI - the Python Package Index - is a repository of software for the Python programming language. The production instance of PyPI lives at https://pypi.org.
 
 As a developer, when you type the command `pip install something`, by default that `something` comes from PyPI. When we create Python packages that might be generally useful to the public (for example, Wagtail plugins), it's nice to consider publishing them to PyPI so others can easily find and use them.
 
@@ -24,7 +24,8 @@ The contents of your project's `setup.py` file determine how your code is packag
 - `author`: should be CFPB.
 - `author_email`: should be tech@cfpb.gov.
 - `description`: short, one line description of the package. This is the headline that appears in PyPI [search results](https://pypi.org/search/?q=wagtail-sharing) and as the headline on the package page.
-- `long_description`: lengthier description that appears on PyPI. Technically this content must be in [reStructuredText](http://docutils.sourceforge.net/rst.html) format. One simple way to implement this is to read in your package's `README.rst` file [like wagtail-sharing does it](https://github.com/cfpb/wagtail-sharing/blob/master/setup.py#L34). Optionally, if you prefer to write your README in Markdown, you can do conversion using pypandoc [like wagtail-flags does it](https://github.com/cfpb/wagtail-flags/blob/master/setup.py#L5). 
+- `long_description`: lengthier description that appears on PyPI. By default this content must be in [reStructuredText](http://docutils.sourceforge.net/rst.html) format. One simple way to implement this is to read in your package's `README.rst` file [like wagtail-sharing does it](https://github.com/cfpb/wagtail-sharing/blob/master/setup.py#L34). 
+- `long_description_content_type`: Optionally, if you prefer to write your README in Markdown, you can set this field to `'text/markdown'`.
 - `classifiers`: this should consist of the list of PyPI trove classifiers that apply to your package, for example the Python and Django versions with which it is compatible. This ensures that your package is properly [searchable on PyPI](https://pypi.org/search/). See the full list of classifiers [here](https://pypi.python.org/pypi?%3Aaction=list_classifiers).
   - This list should always include proper licensing information for your package. This should typically consist of both `'License :: Public Domain'` and `'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication'` due to our default dual licensing described [here](https://github.com/cfpb/development/blob/master/TERMS.md).
   - When possible, licensing classifiers should be used instead of a `license` field in your `setup.py` file. See documentation [here](https://docs.python.org/3.6/distutils/setupscript.html#additional-meta-data) that states (emphasis added):
@@ -42,3 +43,41 @@ When publishing a package developed at CFPB, we ask that you do the following:
 - Add the [cfpb](https://pypi.org/user/cfpb/) PyPI user as an owner of the project. This ensures that someone from the organization will always be able to update the package.
 
 One gotcha: once you've uploaded a particular archive filename to PyPI, [you can never ever upload that same filename again](https://github.com/pypa/packaging-problems/issues/74). This means that if you upload, say, a version 1.0.2, and after publishing realize there was some error, you can't delete and re-upload a new corrected archive as version 1.0.2. You have to instead publish the corrected archive as version 1.0.3.
+
+## Publishing Python Packages Automatically with Travis
+
+It is possible to [publish your packages automatically with Travis](https://docs.travis-ci.com/user/deployment/pypi/) when you create a GitHub release. To do this you must add the following to your `.travis.yml` file:
+
+```yml
+deploy:
+  provider: pypi
+  user: cfpb
+  password:
+    secure: <encrypted password for cfpb>
+  distributions: "sdist bdist_wheel"
+  on:
+    tags: true
+```
+
+This tells Travis to publish both `sdist` and `bdist_wheel` distributions to PyPI as the user `cfpb` with the given password (encrypted using `travis encrypt`) whenever a new git tag is created, which GitHub does when creating a new release. 
+
+If you have multiple targets you can add conditions to the `on` value, for example, to upload wheel files for multiple versions of Python when matrix testing them:
+
+```yml
+deploy:
+  user: cfpb
+  password:
+    secure: <encrypted password for cfpb>
+  - provider: pypi
+    distributions: "sdist bdist_wheel"
+    on:
+      tags: true
+      python: "3.6"
+  - provider: pypi
+    distributions: "bdist_wheel"
+    on:
+      tags: true
+      python: "2.7"
+```
+
+This will avoid matrix failures where an `sdist` cannot be uploaded for a release more than once.


### PR DESCRIPTION
This PR adds information about uploading to PyPI automatically using Travis to our [PyPI guide](https://github.com/cfpb/development/blob/travis-pypi/guides/pypi.md). It also updates some information in the PyPI guide, specifically that PyPI now lives at pypi.org, and that Markdown is supported with a particular value given to the `long_description_content_type` field.

