### PR TITLE
Add manual testing instructions

### DIFF
--- a/guides/browser-support.md
+++ b/guides/browser-support.md
@@ -116,13 +116,17 @@ browsers:
 
 #### Manual testing
 
-We use a mix of Saucelabs and [localtunnel](https://localtunnel.github.io/www/)
-to manually test our site. Be sure to review both the testing and accessibility
+We use a mix of [Sauce Labs](https://saucelabs.com/) and
+[localtunnel](https://localtunnel.github.io/www/) to manually test our site.
+Be sure to review both the
+[testing](https://github.com/cfpb/development/blob/master/guides/testing.md)
+and [accessibility](https://github.com/cfpb/development/blob/master/guides/accessibility.md)
 guides when reviewing sites locally.
 
-##### Saucelabs
+##### Sauce Labs
 
-_Need Cat's demo instructions._
+See [#171](https://github.com/cfpb/development/pull/171) for details on testing
+with Sauce Labs.
 
 ##### localtunnel
 
@@ -137,9 +141,9 @@ npm install -g localtunnel
 Start your project's localhost and in a separate tab run `lt --port 8000`
 editing the port value to match your localhost setup. This will create a
 temporary public URL that can be accessed from any device on any connection.
-Navigate to the URL from your device and test to your hearts content, the URL
+Navigate to the URL from your device and test to your heart's content, the URL
 will remain active as long as the instance is active (keep this in mind, don't
-leave it running forever).
+leave it running forever). Use `ctr + c` to terminate the connection.
 
 #### Individual projects to test
 

--- a/guides/browser-support.md
+++ b/guides/browser-support.md
@@ -114,6 +114,33 @@ browsers:
 - iOS Safari
 - Chrome for Android
 
+#### Manual testing
+
+We use a mix of Saucelabs and [localtunnel](https://localtunnel.github.io/www/)
+to manually test our site. Be sure to review both the testing and accessibility
+guides when reviewing sites locally.
+
+##### Saucelabs
+
+_Need Cat's demo instructions._
+
+##### localtunnel
+
+To test changes using your CFPB issued iPhone or other devices, you'll need to
+use localtunnel to expose your localhost. Start by installing localtunnel if
+you haven't already.
+
+```bash
+npm install -g localtunnel
+```
+
+Start your project's localhost and in a separate tab run `lt --port 8000`
+editing the port value to match your localhost setup. This will create a
+temporary public URL that can be accessed from any device on any connection.
+Navigate to the URL from your device and test to your hearts content, the URL
+will remain active as long as the instance is active (keep this in mind, don't
+leave it running forever).
+
 #### Individual projects to test
 
 - [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/blob/master/CONTRIBUTING.md#browser-support)


### PR DESCRIPTION
Add manual testing instructions to the browser support guide to help ensure developers are adhering to our list of supported browsers.

## Additions

- Added instructions for localtunnel
- Added section for Saucelabs, needs content from @cfarm 

## Testing

1. Follow the instructions to set up localtunnel on your machine.

## Todos

- Add Saucelabs instructions.

## Checklist

- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
