### PR TITLE
Ignore W504, a sibling of W503

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,8 @@ ignore =
     E731,
     # Allow line breaks after binary operators
     W503,
+    # Allow line breaks before binary operators
+    W504,
 
 exclude =
     # Some of this are excluded for speed of directory traversal. Not all of 

--- a/standards/python.md
+++ b/standards/python.md
@@ -16,6 +16,7 @@ Exceptions to PEP8 are found in that [sample flake8 configuration](../.flake8), 
 
 - `E731`, we allow assignment of `lambda` expressions
 - `W503`, we allow line breaks after binary operators
+- `W504`, we allow line breaks before binary operators
 
 On the whole, generated Python files like Django migrations can be safely ignored. 
 


### PR DESCRIPTION
This adds W504, line break before binary operator to our example flake8 configuration. This was recently done in cfgov-refresh in https://github.com/cfpb/cfgov-refresh/pull/4608.

[PEP8 merely requires local consistency](https://legacy.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator) and doesn't preference particular line breaking around binary operators.

An alternative here is we can chose a particular style and enforce it across our code — we'd just need to decide what we want to do (I'd vote strongly in favor of Knuth-style). With this PR we're leaving line breaks around binary operators up to local context (which also makes sense to me given our codebase).