### PR TITLE
Deprecate CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,118 +1,13 @@
-All notable changes to this project will be documented in this file.
+This project no longer uses CHANGELOG.md to track release changes.
 
-## 2019-01-04
+See the project pull request history at:
 
-- Renamed some pages to better reflect their content
+https://github.com/cfpb/development/pulls?q=is%3Apr+is%3Aclosed
 
-## 2017-11-08
+To see the legacy version of this file, visit:
 
-- Add PyPI guide
-- Organize documents and README
+https://github.com/cfpb/development/blob/c054fdb0be46ee91f1dd66b3ce4365f12811fc21/CHANGELOG.md
 
-## 2017-07-14
+or, from the command line:
 
-- Updated to reflect lack of scripting support in IE 8
-
-## 2016-08-26
-
-- Added a starter guide to building atomically.
-
-## 2016-08-25
-
-- Updated guidance on who reviews code and when it should be merged.
-
-## 2016-07-20
-
-### Changed
-
-- Updated ESLint linter file to 3.1.1 compatibility.
-
-## 2015-10-01
-
-### Changed
-
-- Updated ESLint key-spacing mode to "minimum"
-
-## 2015-09-28
-
-### Changed
-
-- Updated ESLint quote-props to "consistent-as-needed"
-
-## 2015-09-22
-
-### Changed
-
-- Updated `README` with full list of links.
-
-
-## 2015-07-06
-
-### Changed
-
-- Updated `.eslintrc` to conform with ESLint 0.24.0.
-
-## 2015-06-02
-
-### Added
-
-- Added jQuery to list of allowed globals in `.eslintrc`
-
-## 2015-05-06
-
-### Added
-
-- 'testing.md': front-end testing tips
-
-## 2015-04-30
-
-### Fixed
-
-- `.eslintrc`: default tab width set to two space
-
-## 2015-04-08
-
-### Added
-
-- 'build.md': a general guideline for front-end build technology
-
-## 2015-04-08
-
-### Added
-
-- `npm.md`: a general guideline for publishing node modules
-- Added a "guides" section to the README
-
-## 2015-04-07
-
-### Added
-
-- `css.md`: initial CSS/Less standards
-
-## 2015-04-06
-
-### Added
-- `javascript.md` a custom fork of <https://github.com/bevacqua/js>
-
-### Deprecated
-- Nothing.
-
-### Removed
-- Nothing.
-
-### Fixed
-- Nothing.
-
-## 2015-03-30
-
-### Added
-- initial markup standards
-
-### Deprecated
-- Nothing.
-
-### Removed
-- Nothing.
-
-### Fixed
-- Nothing.
+git show c054fdb:CHANGELOG.md


### PR DESCRIPTION
As the `CHANGELOG.md` file in this repository has gotten very out of date (at least until @niqjohnson's recent change in #187), we could consider deprecating it and relying instead on GitHub.com's history, as we do with cfgov-refresh.

This PR deprecates the use of `CHANGELOG.md` for tracking changes and replaces it with a placeholder file using the same style as the one in cfgov-refresh:

https://github.com/cfpb/cfgov-refresh/blob/master/CHANGELOG.md