### PR TITLE
Rename "development playbook" link for consistency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@
 
 - [ ] Changes are limited to a single goal (no scope creep)
 - [ ] Code can be automatically merged (no conflicts)
-- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
+- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
 - [ ] Passes all existing automated tests
 - [ ] Any _change_ in functionality is tested
 - [ ] New functions are documented (with a description, list of inputs, and expected output)


### PR DESCRIPTION
This PR renames "development playbook" in the PR template to "CFPB development guidelines" for consistency with how this repo is named in its README and how we refer to it elsewhere.