### PR TITLE
Installing python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Thumbs.db
 *.egg-info/
 __pycache__/
 *.py[cod]
+.python-version
 
 # Django #
 #################

--- a/README.md
+++ b/README.md
@@ -17,24 +17,24 @@ A guide for the development team at the [CFPB](https://cfpb.github.io/).
 ## Guides
 
 - [Start here](guides/start-here.md) – New to software development at the CFPB? Read this first.
+- [Accessibility](guides/accessibility.md)
+- [Atomic Design](guides/atomic-design.md)
+- [Authoring, testing, and publishing npm modules](guides/authoring-npm-modules.md)
 - [Browser support](guides/browser-support.md)
 - [Browser support exceptions](guides/browser-support-exceptions.md): This document
 outlines the decision making process for requesting an exception to current
 browser support standards.
-- [Accessibility](guides/accessibility.md)
-- [Atomic Design](guides/atomic-design.md)
+- [Browser testing with Sauce Labs](guides/browser-testing-with-sauce-labs.md)
 - [Building your project's front-end](guides/build.md)
 - [Code review guide](guides/code-reviews.md)
-- [Documenting your work](guides/documentation.md)
 - [Creating CommonJS modules](guides/creating-commonjs-modules.md)
+- [Documenting your work](guides/documentation.md)
+- [Front-end testing](guides/front-end-testing.md)
 - [Git and GitHub](guides/git.md)
-- [Authoring, testing, and publishing npm modules](guides/authoring-npm-modules.md)
 - [Publishing Python packages to PyPI](guides/pypi.md)
 - [Screen reader differences](guides/screen-reader-differences.md)
-- [Front-end testing](guides/front-end-testing.md)
-- [Browser testing with Sauce Labs](guides/browser-testing-with-sauce-labs.md)
-- [Using npm modules in projects](guides/using-npm-modules-in-projects.md)
 - [Unit testing Django and Wagtail](guides/unittesting-django-wagtail.md)
+- [Using npm modules in projects](guides/using-npm-modules-in-projects.md)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ browser support standards.
 - [Documenting your work](guides/documentation.md)
 - [Front-end testing](guides/front-end-testing.md)
 - [Git and GitHub](guides/git.md)
+- [Installing and using Python 2 and 3](guides/installing-python.md)
 - [Publishing Python packages to PyPI](guides/pypi.md)
 - [Screen reader differences](guides/screen-reader-differences.md)
 - [Unit testing Django and Wagtail](guides/unittesting-django-wagtail.md)

--- a/guides/installing-python.md
+++ b/guides/installing-python.md
@@ -58,7 +58,7 @@ brew install pyenv
 brew install pyenv-virtualenvwrapper
 ```
 
-**Note:** pyenv-virtualenvwrapper is not strictly required, depending on how you wish to manage your virtualenvs. See the [notes in the pyenv-virtualewrapper README](https://github.com/pyenv/pyenv-virtualenvwrapper#pyenv-virtualenvwrapper). Some of our documentation assumes `virtualenvwrapper` exists, so this guide installs it. You will see a deprecation warning when using `mkvirtualenv`:
+**Note:** pyenv-virtualenvwrapper is not strictly required, depending on how you wish to manage your virtualenvs. See the [notes in the pyenv-virtualewrapper README](https://github.com/pyenv/pyenv-virtualenvwrapper#pyenv-virtualenvwrapper). Some of our documentation assumes `virtualenvwrapper` exists, so this guide installs it.
 
 ## Configuring pyenv
 

--- a/guides/installing-python.md
+++ b/guides/installing-python.md
@@ -112,6 +112,8 @@ pyenv local 2.7.15
 
 This will create a `.python-version` file in the current directory. When you're in that directory or below it, pyenv will use the version you've specified here as `python`. 
 
+**Note:** Please ensure that `.python-version` is in the `.gitignore` file for a given repository and that it does not get committed.
+
 **Note:** When you create a virtualenv with `mkvirtualenv` with a local Python version set, it will default to that local Python version, and not the global version. You can still specify `-p` argument with the specific Python you wish to use.
 
 ## Upgrading Python versions

--- a/guides/installing-python.md
+++ b/guides/installing-python.md
@@ -1,27 +1,54 @@
 # Installing and using Python 2 and 3
 
-## Remove Homebrew Python, virtualenvwrapper, and variables
+- [Migrating from Homebrew-installed Python](#migrating-from-homebrew-installed-python)
+   - [Remove Homebrew-installed virtualenvwrapper](#remove-homebrew-installed-virtualenvwrapper)
+   - [Optional: remove Homebrew-installed Python and variables](#optional-remove-homebrew-installed-python-and-variables)
+- [Installing pyenv](#installing-pyenv)
+- [Configuring pyenv](#configuring-pyenv)
+- [Installing Python](#installing-python)
+- [Setting the global Python versions](#setting-the-global-python-versions)
+- [Using local Python versions](#using-local-python-versions)
+- [Upgrading Python versions](#upgrading-python-versions)
+- [Further reading](#further-reading)
 
-Before installing and configuring pyenv, uninstall all old versions of Python that might be installed via Homebrew and virtualenvwrapper, and remove any varaibles from your shell's dotfiles (`.bashrc` for bash users, `.zshrc` for zsh users):
+## Migrating from Homebrew-installed Python
+
+**Note**: Any virtualenvs that you have prior to this process will have to be recreated to use Python from pyenv.
+
+### Remove Homebrew-installed virtualenvwrapper
+
+Before installing and configuring pyenv, uninstall virtualenvwrapper if it  is installed via Homebrew:
+
+```shell
+brew uninstall virtualenvwrapper
+```
+
+Then remove the sourcing of `virtualenvwrapper.sh` and related variables from your shell's dotfiles (`.profile`, `.bashrc` for bash users, `.zshrc` for zsh users):
+
+```shell
+export VIRTUALENVWRAPPER_PYTHON=$HOME/homebrew/bin/python
+export VIRTUALENVWRAPPER_VIRTUALENV=$HOME/homebrew/bin/virtualenv
+source $HOME/homebrew/bin/virtualenvwrapper.sh
+```
+
+### Optional: remove Homebrew-installed Python and variables
+
+Before installing and configuring pyenv, it is a good idea to uninstall all old versions of Python and virtualenvwrapper that might be installed via Homebrew, and remove any varaibles from your shell's dotfiles (`.profile`, `.bashrc` for bash users, `.zshrc` for zsh users):
 
 ```shell
 brew uninstall python
 brew cleanup python
+brew uninstall virtualenvwrapper
 ```
-
-Example of variables you may find that need to be removed:
+You should also remove any variables that reference Homebrew's Python from your shell's dotfiles (`.profile`, `.bashrc` for bash users, `.zshrc` for zsh users), for example:
 
 ```shell
-export WORKON_HOME=$HOME/.virtualenvs
-export VIRTUALENVWRAPPER_PYTHON=$HOME/homebrew/bin/python
-export VIRTUALENVWRAPPER_VIRTUALENV=$HOME/homebrew/bin/virtualenv
-source $HOME/homebrew/bin/virtualenvwrapper.sh
 export PYTHONPATH=$HOME/homebrew/bin/python
 ```
 
-Note: Any virtualenvs that you have prior to this process will have to be recreated. 
+If you do not wish to uninstall Homebrew's Python, or if you have Homebrew-installed packages that depend on Python-installed Homebrew, simply ensure that Homebrew's Python either does not exist in your shell's `PATH` variable, or that it is added to `PATH` *before* the pyenv configuration below.
 
-## Install pyenv
+## Installing pyenv
 
 To [install pyenv on MacOS](https://github.com/pyenv/pyenv#homebrew-on-macos), use Homebrew:
 
@@ -32,16 +59,21 @@ brew install pyenv-virtualenv
 brew install pyenv-virtualenvwrapper
 ```
 
-Note: pyenv-virtualenvwrapper is not strictly required, depending on how you wish to manage your virtualenvs. See the [notes in the pyenv-virtualewrapper README](https://github.com/pyenv/pyenv-virtualenvwrapper#pyenv-virtualenvwrapper). Some of our documentation assumes `virtualenvwrapper` exists, so this guide installs it.
+**Note:** pyenv-virtualenvwrapper is not strictly required, depending on how you wish to manage your virtualenvs. See the [notes in the pyenv-virtualewrapper README](https://github.com/pyenv/pyenv-virtualenvwrapper#pyenv-virtualenvwrapper). Some of our documentation assumes `virtualenvwrapper` exists, so this guide installs it. You will see a deprecation warning when using `mkvirtualenv`:
 
-## Configure pyenv
+```
+WARNING: the pyenv script is deprecated in favour of `python3.6 -m venv`
+```
+
+Until we switch to using Python 3 and the `venv` module full-time, this can be safely ignored.
+
+## Configuring pyenv
 
 Per the [pyenv documentation](https://github.com/pyenv/pyenv#basic-github-checkout), the follow environment variables need to be added to your shell dotfiles (`.bashrc` for bash users, `.zshrc` for zsh users).
 
 ```shell
 # pyenv
 export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
 
 # pyenv-virtualenvwrapper
 export PYENV_VIRTUALENVWRAPPER_PREFER_PYVENV="true"
@@ -56,7 +88,7 @@ pyenv virtualenvwrapper_lazy
 
 Restart your shell.
 
-## Install Python
+## Installing Python
 
 We have projects that require both Python 2.7 and Python 3.6:
 
@@ -67,7 +99,7 @@ pyenv install 2.7.15
 
 With these two versions of Python installed, you 
 
-## Set the global Python versions
+## Setting the global Python versions
 
 By default with pyenv when you invoke `python`, you will be using the system-installed Python. To set the [global Python version to the versions installed above](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-global):
 
@@ -87,3 +119,29 @@ pyenv local 2.7.15
 ```
 
 This will create a `.python-version` file in the current directory. When you're in that directory or below it, pyenv will use the version you've specified here as `python`. 
+
+**Note:** When you create a virtualenv with `mkvirtualenv` with a local Python version set, it will default to that local Python version, and not the global version. You can still specify `-p` argument with the specific Python you wish to use.
+
+## Upgrading Python versions
+
+To change the local Python version to the new version, for example, 3.7.2, follow the same approach you took to setting it the first time:
+
+```shell
+pyenv local 3.7.2
+```
+
+And the local `.python-version` file will contain `3.7.2`.
+
+This does not work for virtualenvs, however. If you install a new version of Python, for example, 3.7.2, you must recreate the virtualenv with the new version of Python. The virtualenv will have be recreated (`mkvirtualenv`) with the new version of Python either set locally, globally, or specified with `-p`.
+
+# Further reading
+
+- [pyenv README](https://github.com/pyenv/pyenv/blob/master/README.md)
+- [pyenv-virtualenvwrapper README](https://github.com/pyenv/pyenv-virtualenvwrapper/blob/master/README.md)
+
+Virtualenv and its alternatives:
+
+- [Introduction to Virtualenvs in the Virtualenv documentation](https://virtualenv.pypa.io/en/stable/#introduction) 
+- [virtualenvwrapper documentation](https://virtualenvwrapper.readthedocs.io/en/latest/)
+- [Python 3's venv module documentation](https://docs.python.org/3/library/venv.html)
+- [pyenv-virtualenv README](https://github.com/pyenv/pyenv-virtualenv/blob/master/README.md)

--- a/guides/installing-python.md
+++ b/guides/installing-python.md
@@ -1,0 +1,89 @@
+# Installing and using Python 2 and 3
+
+## Remove Homebrew Python, virtualenvwrapper, and variables
+
+Before installing and configuring pyenv, uninstall all old versions of Python that might be installed via Homebrew and virtualenvwrapper, and remove any varaibles from your shell's dotfiles (`.bashrc` for bash users, `.zshrc` for zsh users):
+
+```shell
+brew uninstall python
+brew cleanup python
+```
+
+Example of variables you may find that need to be removed:
+
+```shell
+export WORKON_HOME=$HOME/.virtualenvs
+export VIRTUALENVWRAPPER_PYTHON=$HOME/homebrew/bin/python
+export VIRTUALENVWRAPPER_VIRTUALENV=$HOME/homebrew/bin/virtualenv
+source $HOME/homebrew/bin/virtualenvwrapper.sh
+export PYTHONPATH=$HOME/homebrew/bin/python
+```
+
+Note: Any virtualenvs that you have prior to this process will have to be recreated. 
+
+## Install pyenv
+
+To [install pyenv on MacOS](https://github.com/pyenv/pyenv#homebrew-on-macos), use Homebrew:
+
+```shell
+brew update
+brew install pyenv
+brew install pyenv-virtualenv
+brew install pyenv-virtualenvwrapper
+```
+
+Note: pyenv-virtualenvwrapper is not strictly required, depending on how you wish to manage your virtualenvs. See the [notes in the pyenv-virtualewrapper README](https://github.com/pyenv/pyenv-virtualenvwrapper#pyenv-virtualenvwrapper). Some of our documentation assumes `virtualenvwrapper` exists, so this guide installs it.
+
+## Configure pyenv
+
+Per the [pyenv documentation](https://github.com/pyenv/pyenv#basic-github-checkout), the follow environment variables need to be added to your shell dotfiles (`.bashrc` for bash users, `.zshrc` for zsh users).
+
+```shell
+# pyenv
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+# pyenv-virtualenvwrapper
+export PYENV_VIRTUALENVWRAPPER_PREFER_PYVENV="true"
+export WORKON_HOME=$HOME/.virtualenvs
+
+# Ensure this placed toward the end of the file
+eval "$(pyenv init -)"
+
+# Load virtualenvwrapper
+pyenv virtualenvwrapper_lazy
+```
+
+Restart your shell.
+
+## Install Python
+
+We have projects that require both Python 2.7 and Python 3.6:
+
+```shell
+pyenv install 3.6.8
+pyenv install 2.7.15
+```
+
+With these two versions of Python installed, you 
+
+## Set the global Python versions
+
+By default with pyenv when you invoke `python`, you will be using the system-installed Python. To set the [global Python version to the versions installed above](https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-global):
+
+```shell
+pyenv global 3.6.8 2.7.15
+```
+
+This will make `python` version 3.6.8, and `python2` will be 2.7.15. This is our recommended configuration.
+
+
+## Using local Python versions
+
+pyenv also allows you to set a local Python version (the version of Python that is available in the current directory):
+
+```shell
+pyenv local 2.7.15
+```
+
+This will create a `.python-version` file in the current directory. When you're in that directory or below it, pyenv will use the version you've specified here as `python`. 

--- a/guides/installing-python.md
+++ b/guides/installing-python.md
@@ -40,7 +40,7 @@ brew uninstall python
 brew cleanup python
 brew uninstall virtualenvwrapper
 ```
-You should also remove any variables that reference Homebrew's Python from your shell's dotfiles (`.profile`, `.bashrc` for bash users, `.zshrc` for zsh users), for example:
+You should also remove any variables that reference Homebrew's Python from your shell's dotfiles (`.profile`, `.bashrc` for bash users, `.zshrc` for zsh users), for example, removing:
 
 ```shell
 export PYTHONPATH=$HOME/homebrew/bin/python
@@ -61,15 +61,9 @@ brew install pyenv-virtualenvwrapper
 
 **Note:** pyenv-virtualenvwrapper is not strictly required, depending on how you wish to manage your virtualenvs. See the [notes in the pyenv-virtualewrapper README](https://github.com/pyenv/pyenv-virtualenvwrapper#pyenv-virtualenvwrapper). Some of our documentation assumes `virtualenvwrapper` exists, so this guide installs it. You will see a deprecation warning when using `mkvirtualenv`:
 
-```
-WARNING: the pyenv script is deprecated in favour of `python3.6 -m venv`
-```
-
-Until we switch to using Python 3 and the `venv` module full-time, this can be safely ignored.
-
 ## Configuring pyenv
 
-Per the [pyenv documentation](https://github.com/pyenv/pyenv#basic-github-checkout), the follow environment variables need to be added to your shell dotfiles (`.bashrc` for bash users, `.zshrc` for zsh users).
+Per the [pyenv documentation](https://github.com/pyenv/pyenv#basic-github-checkout), the follow environment variables need to be added to your shell dotfiles (`.profile`, `.bashrc` for bash users, `.zshrc` for zsh users).
 
 ```shell
 # pyenv
@@ -97,7 +91,7 @@ pyenv install 3.6.8
 pyenv install 2.7.15
 ```
 
-With these two versions of Python installed, you 
+Before you can use either of these versions of Python, you have to set them as either global or local versions.
 
 ## Setting the global Python versions
 
@@ -132,7 +126,11 @@ pyenv local 3.7.2
 
 And the local `.python-version` file will contain `3.7.2`.
 
-This does not work for virtualenvs, however. If you install a new version of Python, for example, 3.7.2, you must recreate the virtualenv with the new version of Python. The virtualenv will have be recreated (`mkvirtualenv`) with the new version of Python either set locally, globally, or specified with `-p`.
+This does not work for virtualenvs, however. If you install a new version of Python, for example, 3.7.2, you must recreate the virtualenv with the new version of Python. The virtualenv will have be recreated (`mkvirtualenv`) with the new version of Python either set locally, globally, or specified with `--python`:
+
+```shell
+mkvirtualenv --python=python2.7 [virtualenv name]
+```
 
 # Further reading
 

--- a/guides/installing-python.md
+++ b/guides/installing-python.md
@@ -55,7 +55,6 @@ To [install pyenv on MacOS](https://github.com/pyenv/pyenv#homebrew-on-macos), u
 ```shell
 brew update
 brew install pyenv
-brew install pyenv-virtualenv
 brew install pyenv-virtualenvwrapper
 ```
 
@@ -70,7 +69,6 @@ Per the [pyenv documentation](https://github.com/pyenv/pyenv#basic-github-checko
 export PYENV_ROOT="$HOME/.pyenv"
 
 # pyenv-virtualenvwrapper
-export PYENV_VIRTUALENVWRAPPER_PREFER_PYVENV="true"
 export WORKON_HOME=$HOME/.virtualenvs
 
 # Ensure this placed toward the end of the file


### PR DESCRIPTION
This change adds a new document describing how to install Python 2 and 3 using pyenv. This is intended to help standardize how we install and use multiple versions of Python so that we have as much consistency as possible.

This is based on work done by the backends on our PyFridays, including the initial heavy-lifting done by @hillaryj (this work is recorded in GHE at CFGOV/platform/wiki/Pyenv). This is submitted for review/testing/etc as a first-pass. 

Before we merge this in we'll probably want to update some of the documentation for our major projects ([*cough*](https://cfpb.github.io/cfgov-refresh/installation/)) to reference this and ensure that there are no conflicts between what they this tells you to do and our other documents.

But given that [cfgov-refresh tox and Travis now run the backend tests in Python 2 and Python 3](https://github.com/cfpb/cfgov-refresh/pull/4865), we should have somewhere to point folks to ensure they can set themselves up to to write passing tests.

As always, I like GitHub rendering for reviewing new documents:

https://github.com/cfpb/development/blob/installing-python/guides/installing-python.md

I've also alphabetized the Guides section of the README. It looks like that was the original intent, but it hasn't been maintained.