### PR TITLE
Add git-secrets documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ browser support standards.
 - [Front-end testing](guides/front-end-testing.md)
 - [Git and GitHub](guides/git.md)
 - [Installing and using Python 2 and 3](guides/installing-python.md)
+- [Patterns for git-secrets](tools/git-secrets-patterns/README.md)
 - [Publishing Python packages to PyPI](guides/pypi.md)
 - [Screen reader differences](guides/screen-reader-differences.md)
 - [Unit testing Django and Wagtail](guides/unittesting-django-wagtail.md)


### PR DESCRIPTION
The git-secrets documentation isn't linked from the README. This PR fixes that.
