### PR TITLE
Resolve spacing and regular expression issues in git-secrets instructions and patterns

### DIFF
--- a/tools/git-secrets-patterns/README.md
+++ b/tools/git-secrets-patterns/README.md
@@ -12,7 +12,7 @@ This is a set of patterns for use with git-secrets, which we can use to keep sen
 
 1. Check this repo out to your filesystem
 
-1. Install the default patterns into git-secrets with `git secrets  --add-provider -- grep -v \#  /path/to/development/tools/git-secret-patterns/default.txt`
+1. Install the default patterns into git-secrets with `git secrets  --add-provider -- egrep -v '^$|^#' /path/to/development/tools/git-secret-patterns/default.txt`
 
 ## Usage
 

--- a/tools/git-secrets-patterns/README.md
+++ b/tools/git-secrets-patterns/README.md
@@ -12,7 +12,7 @@ This is a set of patterns for use with git-secrets, which we can use to keep sen
 
 1. Check this repo out to your filesystem
 
-1. Install the default patterns into git-secrets with `git secrets  --add-provider -- egrep -v '^$|^#' /path/to/development/tools/git-secret-patterns/default.txt`
+1. Install the default patterns into git-secrets with `git secrets  --add-provider --global -- egrep -v '^$|^#' /path/to/development/tools/git-secret-patterns/default.txt`
 
 ## Usage
 

--- a/tools/git-secrets-patterns/default.txt
+++ b/tools/git-secrets-patterns/default.txt
@@ -18,10 +18,6 @@ uname[\s]*=[\s]*.+
 # Email addresses
 [A-Z0-9._%-]+@[A-Z0-9.\-]+\.[A-Z]{2,4}
 
-# Credit cards
-# Credit: grep Pocket Reference, 2009 O'Reilly Publishing
-\b[0-9]{4}(( |-|)[0-9]{4}){3}\b
-
 # Private keys
 \-\-\-\-\-BEGIN\sRSA\sPRIVATE\sKEY\-\-\-\-\-.*\-\-\-\-\-END\sRSA\sPRIVATE\sKEY\-\-\-\-\-
 SECRET_KEY


### PR DESCRIPTION
This PR modifies our git-secrets instructions to exclude comments *and* newlines. 

It also removes the credit card regular expression. This regex was causing issues when excluding newlines (`grep: empty (sub)expression`, described in #196). It also does not match many formats of credit card numbers. I believe it's better to not have any cred card number matching at all than to rely on matching that will not match American Express cards and other formats. So I have removed it. We can work to craft a new one at a later date.

Closes #196.
