### PR TITLE
Update links to Wagtail docs

### DIFF
--- a/guides/unittesting-django-wagtail.md
+++ b/guides/unittesting-django-wagtail.md
@@ -9,7 +9,7 @@
     - [Overriding settings](#overriding-settings)
     - [Mocking](#mocking)
 - [Running tests](#running-tests)
-    
+
 - [Common test patterns](#common-test-patterns)
     - [Django models](#django-models)
     - [Django views](#django-views)
@@ -24,7 +24,7 @@
 ### Documentation
 
 - [The Django testing documentation](https://docs.djangoproject.com/en/1.11/topics/testing/overview/)
-- [The Wagtail testing documentation](http://docs.wagtail.io/en/v1.13.4/advanced_topics/testing.html)
+- [The Wagtail testing documentation](https://docs.wagtail.io/en/stable/advanced_topics/testing.html)
 - [Real Python's "Testing in Django"](https://realpython.com/testing-in-django-part-1-best-practices-and-examples/)
 
 ### Inspiration
@@ -36,7 +36,7 @@
 
 ### Choosing a `TestCase` base class
 
-When writing unit tests for code in cfgov-refresh there are multiple possible test case base classes that can be used. 
+When writing unit tests for code in cfgov-refresh there are multiple possible test case base classes that can be used.
 
 - [`unittest.TestCase`](https://docs.python.org/3.6/library/unittest.html#unittest.TestCase): For testing Python code that does not interact with Django or Wagtail. This class provides all the base Python unit test assertions, such as:
 
@@ -81,30 +81,30 @@ When writing unit tests for code in cfgov-refresh there are multiple possible te
 
 There are a few different ways to provide data for your tests to operate on.
 
-- Using [Django test fixtures](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#fixture-loading) to load specific data into the database. 
+- Using [Django test fixtures](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#fixture-loading) to load specific data into the database.
 
-    Generally we use Django test fixtures when we need to test a fairly large amount of data with fixed values that matter to multiple tests. For example, when [testing the interactive regulations search indexes](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/regulations3k/tests/test_search_indexes.py#L16). 
-    
+    Generally we use Django test fixtures when we need to test a fairly large amount of data with fixed values that matter to multiple tests. For example, when [testing the interactive regulations search indexes](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/regulations3k/tests/test_search_indexes.py#L16).
+
     ```python
     class RegulationIndexTestCase(TestCase):
         fixtures = ['tree_limb.json']
         index = RegulationParagraphIndex()
-    
+
         def test_index(self):
             self.assertEqual(self.index.get_model(), SectionParagraph)
             self.assertEqual(self.index.index_queryset().count(), 13)
             self.assertIs(
-                self.index.index_queryset().first().section.subpart.version.draft, 
+                self.index.index_queryset().first().section.subpart.version.draft,
                 False
             )
     ```
-    
+
     The best way to create test fixtures is to add the objects manually and then use the [Django `manage.py dumpdata` command](https://docs.djangoproject.com/en/1.11/ref/django-admin/#django-admin-dumpdata) to dump the objects to JSON.
 
-- Using [Model Mommy](https://model-mommy.readthedocs.io/en/latest/index.html) to create test data automatically in code. 
+- Using [Model Mommy](https://model-mommy.readthedocs.io/en/latest/index.html) to create test data automatically in code.
 
     Generally use use Model Mommy when we need to test operations on a model whose values are unimportant to the outcome. Occasionlly we will pass specific values to Model Mommy when those values are important to the tests. An example is when [testing operations around image models and the way they're handled](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/test_meta_image.py#L14), when we want to make sure that the model gets rendered correctly.
-    
+
     ```python
     class TestMetaImage(TestCase):
         def setUp(self):
@@ -117,10 +117,10 @@ There are a few different ways to provide data for your tests to operate on.
                 social_sharing_image=self.social_sharing_image,
                 preview_image=self.preview_image
             )
-            self.assertEqual(page.meta_image, page.social_sharing_image)    
+            self.assertEqual(page.meta_image, page.social_sharing_image)
     ```
 
-- Creating specific instances of models in code. 
+- Creating specific instances of models in code.
 
     All other test data needs are generally accomplished by creating instances of models directly. For example, our [Django-Flags `DatabaseFlagsSource` test case](https://github.com/cfpb/django-flags/blob/master/flags/tests/test_sources.py#L46-L56) tests that a database-stored `FlagState` object is provided by the `DatabaseFlagsSource` class. To do that it creates a specific instance of `FlagState` using `FlagStage.objects.create()` that it expects to be returned:
 
@@ -146,21 +146,21 @@ It is sometimes useful to modify Django settings when testing code that may beha
 
 - [`@override_settings()`](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#django.test.override_settings) will override the contents of a setting variable.
 
-  We use `@override_settings` any time the outcome of the code being tested depends on a settings variable. 
-  
-  This can include testing different values of feature flags: 
-  
+  We use `@override_settings` any time the outcome of the code being tested depends on a settings variable.
+
+  This can include testing different values of feature flags:
+
   ```python
   @override_settings(FLAGS={'MYFLAG': [('boolean', True)]})
   ```
-  
+
   Or when we need to test behavior with AWS S3:
-  
+
   ```python
   @override_settings(AWS_STORAGE_BUCKET_NAME='test.bucket')
   ```
-  
-- [`@modify_settings()`](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#django.test.modify_settings) will modify specific values within a list setting. 
+
+- [`@modify_settings()`](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#django.test.modify_settings) will modify specific values within a list setting.
 
 ### Mocking
 
@@ -171,7 +171,7 @@ We use the [Python Mock library](https://docs.python.org/3/library/unittest.mock
 - External service calls.
 
     For example, we have a custom Wagtail admin view that allows users to flush the Akamai cache for specific URLs. One of the tests for that view mocks calls to the Akamai `purge()` method within the module being tested to ensure that it is called with the URL that needs to be purged:
-        
+
     ```python
     from django.test import TestCase
     import mock
@@ -186,7 +186,7 @@ We use the [Python Mock library](https://docs.python.org/3/library/unittest.mock
             mock_purge.assert_called_with('http://fake.gov')
     ```
 
-- Logging introspection, to ensure that a message that should be logged does get logged. 
+- Logging introspection, to ensure that a message that should be logged does get logged.
 
     For example, to mock a module-level logger initialzed with `logger = logging.getLogger(__name__)`, we can patch the the `logging.Logger.info` method and make asserts based on its call arguments:
 
@@ -222,7 +222,7 @@ class ComplaintLandingViewTests(TestCase):
 
 #### Mocking boto with moto
 
-When we need to mock AWS services that are called via [boto](https://github.com/boto/boto/) we use the [moto](https://github.com/spulec/moto) library. For example, [to test our S3 utilities](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/test_s3utils.py#L21-L25), we initialize moto in our test case's `setUp` method: 
+When we need to mock AWS services that are called via [boto](https://github.com/boto/boto/) we use the [moto](https://github.com/spulec/moto) library. For example, [to test our S3 utilities](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/test_s3utils.py#L21-L25), we initialize moto in our test case's `setUp` method:
 
 ```python
 class S3UtilsTestCase(TestCase):
@@ -237,7 +237,7 @@ From there calls to boto's S3 API will use the moto mock S3.
 
 ## Running tests
 
-To run Django and Wagtail unit tests we prefer to use [tox](https://tox.readthedocs.io/en/latest/). tox creates and manages virtual environments for running tests against multiple versions of dependencies. 
+To run Django and Wagtail unit tests we prefer to use [tox](https://tox.readthedocs.io/en/latest/). tox creates and manages virtual environments for running tests against multiple versions of dependencies.
 
 CFPB has a [sample `tox.ini`](https://github.com/cfpb/development/blob/master/tox.ini) that will test against Django 1.11 and 2.1 and Python 3.6. Additionally, running the tests for [CFPB's cfgov-refresh Django project are documented with that project](https://cfpb.github.io/cfgov-refresh/testing-be/).
 
@@ -272,7 +272,7 @@ from regulations3k.models.django import Part
 class RegModelTests(TestCase):
     def setUp(self):
         self.part = mommy.make(Part)
-        
+
     def test_part_cfr_title(self):
         self.assertEqual(
             self.part.cfr_title,
@@ -288,14 +288,14 @@ class RegModelTests(TestCase):
 
 Testing Django views requires responding to a `request` object. Django provides multiple ways to provide such objects:
 
-- [`django.test.Client`](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#the-test-client) is a dummy web browser that can perform `GET` and `POST` requests on a URL and return the full HTTP response. 
+- [`django.test.Client`](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#the-test-client) is a dummy web browser that can perform `GET` and `POST` requests on a URL and return the full HTTP response.
 
     `Client` is useful for when you need to ensure the view is called appropriately from its URL pattern and whether it returns the correct HTTP headers and status codes in its response. All `django.test.TestCase` subclasses get a `self.client` object that is ready to make requests.
-     
+
     *Note*: Requests made with `django.test.Client` include all Django request handling, including middleware. See [overriding settings](#overriding-settings) if this is a problem.
-    
+
     The mortgage performance tests use a [combination of fixtures and Model Mommy-created models](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/data_research/tests/test_views.py#L47-L148) to set up for testing the timeseries view's response code and response data:
-    
+
     ```python
     from django.test import TestCase
     from django.core.urlresolvers import reverse
@@ -311,22 +311,22 @@ Testing Django views requires responding to a `request` object. Django provides 
             self.assertEqual(response.status_code, 200)
             self.assertIn('No metadata object found.', response.content)
     ```
-    
+
     Note the use of `django.core.urlresolvers.reverse` and named URL patterns to look up the URL rather than hard-coding URLs directly in tests.
 
-- [`django.test.RequestFactory`](https://docs.djangoproject.com/en/1.11/topics/testing/advanced/#django.test.RequestFactory) shares the `django.test.Client` API, but instead of performing the request it simply generates a `request` object that can then be passed to a view manually. 
+- [`django.test.RequestFactory`](https://docs.djangoproject.com/en/1.11/topics/testing/advanced/#django.test.RequestFactory) shares the `django.test.Client` API, but instead of performing the request it simply generates a `request` object that can then be passed to a view manually.
 
     Using a `RequestFactory` generated request is useful when you wish to call the view function or class directly, without going through Django's URL dispatcher or any middleware.
-    
+
     The Data & Research [conference registration handler tests](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/models/test_base.py#L21) use a `RequestFactory` to generate requests with various inputs, including how a `GET` parameter is handled:
-    
+
     ```python
     from django.test import RequestFactory , TestCase
-     
+
     class TestConferenceRegistrationHandler(TestCase):
         def setUp(self):
             self.factory = RequestFactory()
-            
+
         def test_request_with_query_string_marks_successful_submission(self):
             request = self.factory.get('/?success')
             handler = ConferenceRegistrationHandler(
@@ -340,7 +340,7 @@ We generally do not recommend creating `django.http.HttpRequest` objects directl
 
 ### Wagtail pages
 
-[Wagtail pages](http://docs.wagtail.io/en/v1.13.4/topics/pages.html) are special kinds of Django models that form the basis of the Content Management System. They provide many opportunities to override default methods (like `get_template()`) which need testing just like [Django models](#django-models), but they also provide their own view via the `serve()` method, which makes them testable like [Django views](#django-views). 
+[Wagtail pages](https://docs.wagtail.io/en/stable/topics/pages.html) are special kinds of Django models that form the basis of the Content Management System. They provide many opportunities to override default methods (like `get_template()`) which need testing just like [Django models](#django-models), but they also provide their own view via the `serve()` method, which makes them testable like [Django views](#django-views).
 
 In general the same principle applies to Wagtail pages as to Django models: any custom method or properties should be unit tested.
 
@@ -361,9 +361,9 @@ class JobListingPageTestCase(TestCase):
         city = City(name='Townsville', state=state)
         region.cities.add(city)
         page = mommy.make(JobListingPage, location=region)
-        
+
         test_context = page.get_context(self.factory.get('/'))
-        
+
         self.assertEqual(len(test_context['states']), 1)
         self.assertEqual(test_context['states'][0], state.abbreviation)
         self.assertEqual(len(test_context['cities']), 1)
@@ -372,7 +372,7 @@ class JobListingPageTestCase(TestCase):
 
 ### Wagtail blocks
 
-[Wagtail StreamFields](http://docs.wagtail.io/en/v1.13.4/topics/streamfield.html) provide blocks that can be added to Wagtail pages. Blocks define a field schema and render those fields independent of the rest of the page. 
+[Wagtail StreamFields](https://docs.wagtail.io/en/stable/topics/streamfield.html) provide blocks that can be added to Wagtail pages. Blocks define a field schema and render those fields independent of the rest of the page.
 
 As with Wagtail pages and Django models, any custom method or properties should be unit tested. Additionally, it may be important to test to the way a block renders. For example, the basic Wagtail [`DateTimeBlock` unit test](https://github.com/wagtail/wagtail/blob/master/wagtail/core/tests/test_blocks.py#L2950-L2963) tests that the block renders the date value that's given:
 
@@ -396,7 +396,7 @@ class TestDateTimeBlock(SimpleTestCase):
 )
 ```
 
-More complicated blocks' fields are stored as JSON on the page object. To prepare that JSON as the block's `value` to pass to the block's `render()` and other methods, the `block.to_python()` method is used. 
+More complicated blocks' fields are stored as JSON on the page object. To prepare that JSON as the block's `value` to pass to the block's `render()` and other methods, the `block.to_python()` method is used.
 
 For example, the `TextIntroduction` block [requires its `heading` field when the `eyebrow` field is given](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/atomic_elements/molecules.py#L98-L105). This is tested by checking if a [`ValidationError` is raised in `block.clean(value)`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/atomic_elements/test_molecules.py#L250-L255). To prepare a value to pass, `to_python()` is used:
 
@@ -415,7 +415,7 @@ class TestTextIntroductionValidation(SimpleTestCase):
 
 ### Wagtail admin customizations
 
-It is occasionally useful to test custom Wagtail admin views and `ModelAdmin`s for Django models. 
+It is occasionally useful to test custom Wagtail admin views and `ModelAdmin`s for Django models.
 
 When testing the admin Wagtail contains a useful mixin class for test cases, `wagtail.tests.utils.WagtailTestUtils`, which provides a `login()` method which will create a superuser and login for all `self.client` requests.
 
@@ -430,7 +430,7 @@ class TestWagtailFlagsViews(TestCase, WagtailTestUtils):
         self.login()
 ```
 
-The custom admin view that Wagtail-Flags provides can then be tested like any [Django view](#django-views): 
+The custom admin view that Wagtail-Flags provides can then be tested like any [Django view](#django-views):
 
 ```python
     def test_flags_index(self):
@@ -442,7 +442,7 @@ We generally recommend using `WagtailTestUtils` to login and test the admin unle
 
 ### Django management commands
 
-When testing custom management commands [Django provides a `call_command()` function](https://docs.djangoproject.com/en/2.1/topics/testing/tools/#management-commands) which will call the command direct the output into a `StringIO` object to be introspected. 
+When testing custom management commands [Django provides a `call_command()` function](https://docs.djangoproject.com/en/2.1/topics/testing/tools/#management-commands) which will call the command direct the output into a `StringIO` object to be introspected.
 
 For example, our [custom makemessages command (that adds support for Jinja2 templates)](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/management/commands/makemessages.py) is tested [using `call_command()`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/management/commands/test_makemessages.py#L66) (although it inspects the resulting `.po` file):
 
@@ -463,11 +463,11 @@ class TestCustomMakeMessages(SimpleTestCase):
 
 ### Feature-flagged code
 
-We use [Django-Flags](https://cfpb.github.io/django-flags/) to feature flag code that should be run under certain conditions, such as waiting for a particular launch window or to A/B test. Sometimes it is necessary to test that code is actually flagged. 
+We use [Django-Flags](https://cfpb.github.io/django-flags/) to feature flag code that should be run under certain conditions, such as waiting for a particular launch window or to A/B test. Sometimes it is necessary to test that code is actually flagged.
 
 In all cases, the easiest way to test with explicit flag states is to [override the `FLAGS` setting](#overriding-settings) and include only your specific flag with a `boolean` condition of `True`.
 
-For example, to test [a function that serves a URL via Wagtail depending on the state of a flag](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/urls.py#L42-L53), the base URL tests [check behavior with a flag explicitly enabled and again with that flag explicitly disabled](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/tests/test_urls.py#L92-L109): 
+For example, to test [a function that serves a URL via Wagtail depending on the state of a flag](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/urls.py#L42-L53), the base URL tests [check behavior with a flag explicitly enabled and again with that flag explicitly disabled](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/tests/test_urls.py#L92-L109):
 
 ```python
 class FlaggedWagtailOnlyViewTests(TestCase):


### PR DESCRIPTION
With the upgrade to Wagtail 2.3, we've decided that all links to Wagtail docs can now point to the `stable` version of the docs.

## Changes

- Updated all the links to Wagtail docs to point to the `stable` version instead of the `1.13.4` version.
- Updated all the links to Wagtail docs to use `https` instead of `http`.
- Looks like a bunch of white space changes snuck in, too—thanks, VSCode.

## Testing

1. Make sure the three updated links (L27, L343, L375) all work.
2. I guess also make sure none of the whitespace changes VSCode made break anything?

## Checklist

- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: