### PR TITLE
Add Black to our Python standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.black]
+line-length = 79
+target-version = ['py36', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.tox
+    | \*.egg-info
+    | _build
+    | build
+    | dist
+    | migrations
+  )/
+)
+'''
+
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/standards/python.md
+++ b/standards/python.md
@@ -13,7 +13,7 @@ All of our Python code should match the [PEP8 style guide](https://www.python.or
 
 We follow [PEP8's line length](https://www.python.org/dev/peps/pep-0008/#maximum-line-length) instead of Django's for consistency with our other development standards. We follow [Django's recommended import ordering in Django projects](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#imports).
 
-We use [Black](http://black.readthedocs.io) to standardize formatting of our Python code and make linting easier. We do override the default line length for Black, however, to 78. We also exclude generated files like migrations. We provide a sample [`pyproject.toml` file containing line length and exclude configuration for Black](../pyproject.toml).
+We use [Black](http://black.readthedocs.io) to standardize formatting of our Python code and make linting easier. We override the default Black line length to 79 to match PEP8. We also exclude generated files like migrations. We provide a sample [`pyproject.toml` file containing line length and exclude configuration for Black](../pyproject.toml).
 
 ## Linting
 

--- a/standards/python.md
+++ b/standards/python.md
@@ -1,16 +1,21 @@
 # Python Standards
 
+- [Style](#style)
 - [Linting](#linting)
 - [Imports](#imports)
 - [Dependency support/testing matrix](#dependency-supporttesting-matrix)
   - [Considerations](#considerations)
   - [Specifying dependencies in `requirements.txt` or `setup.py`](#specifying-dependencies-in-requirementstxt-or-setuppy)
 
-## Linting
+## Style
 
 All of our Python code should match the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/) and the [Django coding style guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/).
 
 We follow [PEP8's line length](https://www.python.org/dev/peps/pep-0008/#maximum-line-length) instead of Django's for consistency with our other development standards. We follow [Django's recommended import ordering in Django projects](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#imports).
+
+We use [Black](http://black.readthedocs.io) to standardize formatting of our Python code and make linting easier. We do override the default line length for Black, however, to 78. We also exclude generated files like migrations. We provide a sample [`pyproject.toml` file containing line length and exclude configuration for Black](../pyproject.toml).
+
+## Linting
 
 For linting we recommend [flake8](http://flake8.pycqa.org/en/latest/), and provide a [sample flake8 configuration](../.flake8).
 Exceptions to PEP8 are found in that [sample flake8 configuration](../.flake8), and include:


### PR DESCRIPTION
We've started using Black in [various](https://github.com/cfpb/django-flags) [projects](https://github.com/cfpb/retirement) and it has been helpful as we need to add linting to projects that predate our linting standards.

This change adds documentation about how we're using Black and clarifies that we've deviating from Black's preferences on line length (because we're all set up for our standard PEP8 79 char).