### PR TITLE
Update the isort example config

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,7 +2,6 @@
 include_trailing_comma=1
 multi_line_output=3
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_future_library=future

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps=
     isort>=4.2.15
 commands=
     flake8 .
-    isort --check-only --diff --recursive .
+    isort --check-only --diff .


### PR DESCRIPTION
This change updates the isort example config to remove the `not_skip` setting that was deprecated and removed in [isort 5.0](https://github.com/timothycrosley/isort/blob/5.0.0/CHANGELOG.md#500-penny---july-4-2020).

See some additional context in https://github.com/cfpb/cfgov-refresh/pull/5840.