### PR TITLE
Rename cfgov-refresh to consumerfinance.gov

### DIFF
--- a/guides/browser-support.md
+++ b/guides/browser-support.md
@@ -147,7 +147,7 @@ leave it running forever). Use `ctr + c` to terminate the connection.
 
 #### Individual projects to test
 
-- [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/blob/master/CONTRIBUTING.md#browser-support)
+- [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov/blob/master/CONTRIBUTING.md#browser-support)
 - [Design System](https://github.com/cfpb/design-system/blob/master/CONTRIBUTING.md#browser-support)
 - [Paying for College](https://github.com/cfpb/college-costs/blob/master/CONTRIBUTING.md#browser-support)
 - [Retirement](https://github.com/cfpb/retirement/blob/master/CONTRIBUTING.md#browser-support)

--- a/guides/documentation.md
+++ b/guides/documentation.md
@@ -32,15 +32,15 @@ This documentation is written in Markdown and browseable
 [on GitHub](https://github.com/cfpb/development#cfpb-development-guidelines).
 
 Documentation specific to [https://www.consumerfinance.gov](https://www.consumerfinance.gov)
-or the software that powers it should live in the [cfgov-refresh](https://github.com/cfpb/cfgov-refresh) repository.
-Documentation is written as [Markdown files](https://github.com/cfpb/cfgov-refresh/tree/master/docs)
+or the software that powers it should live in the [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov) repository.
+Documentation is written as [Markdown files](https://github.com/cfpb/consumerfinance.gov/tree/master/docs)
 in that repository, converted to HTML by [MkDocs](https://www.mkdocs.org/),
-and served by GitHub Pages at [https://cfpb.github.io/cfgov-refresh/](https://cfpb.github.io/cfgov-refresh/).
+and served by GitHub Pages at [https://cfpb.github.io/consumerfinance.gov/](https://cfpb.github.io/consumerfinance.gov/).
 
 Documentation specific to other projects should live in that project's repository.
 Exceptions to this include repositories that only work within the context of a larger project,
 for example the cf.gov satellite apps.
-In that case it may be appropriate to locate documentation within the cfgov-refresh repository,
+In that case it may be appropriate to locate documentation within the consumerfinance.gov repository,
 as long as the satellite app contains a link pointing to the appropriate location.
 
 ## Documentation definition of done
@@ -66,7 +66,7 @@ See ["Where to put documentation"](#where-to-put-documentation) above for additi
 Documentation should be linked to from an appropriate landing page
 (for example, [this repository's README](https://github.com/cfpb/development/blob/master/README.md))
 and, if possible, be discoverable through search
-(for example, [the cfgov-refresh docs search](https://cfpb.github.io/cfgov-refresh/search.html?q=testing)).
+(for example, [the consumerfinance.gov docs search](https://cfpb.github.io/consumerfinance.gov/search.html?q=testing)).
 
 The onboarding of new team members can be a great opportunity to review and
 update existing documentation to ensure that it meets these goals.
@@ -93,10 +93,10 @@ for example by using anchor links
 ([like this](https://github.com/cfpb/development/#guides)) to target specific places on the page.
 When referencing specific lines in source code, consider linking to specific
 releases or commit hashes instead of the master branch
-([this](https://github.com/cfpb/cfgov-refresh/blob/7.2.2/tox.ini#L105) or
-[this](https://github.com/cfpb/cfgov-refresh/blob/fb16e906bc4935669f880c270ccf4e32b930b068/tox.ini#L105)
+([this](https://github.com/cfpb/consumerfinance.gov/blob/7.2.2/tox.ini#L105) or
+[this](https://github.com/cfpb/consumerfinance.gov/blob/fb16e906bc4935669f880c270ccf4e32b930b068/tox.ini#L105)
 instead of
-[this](https://github.com/cfpb/cfgov-refresh/blob/master/tox.ini#L105))
+[this](https://github.com/cfpb/consumerfinance.gov/blob/master/tox.ini#L105))
 when the file being linked to is likely to change often and a specific line reference would be hard to maintain.
 Links to the master branch of source code should be used as long as the
 documentation is updated appropriately when the source files are.

--- a/guides/front-end-testing.md
+++ b/guides/front-end-testing.md
@@ -23,7 +23,7 @@ Check out 18f's excellent [testing cookbook](https://pages.18f.gov/testing-cookb
 
 ## Code coverage
 
-The goal is to have all of your code covered by unit tests. Tools known as code coverage reporters will tell you what percentage of your codebase is covered by tests. The cfgov-refresh (consumerfinance.gov) project uses [Jest](https://github.com/facebook/jest/). When cfgov-refresh unit tests are run using `gulp test:unit`, a coverage report with coverages percentages is printed to the command line. It also generates an interactive HTML code coverage report in `test/unit_test_coverage`.
+The goal is to have all of your code covered by unit tests. Tools known as code coverage reporters will tell you what percentage of your codebase is covered by tests. The consumerfinance.gov (consumerfinance.gov) project uses [Jest](https://github.com/facebook/jest/). When consumerfinance.gov unit tests are run using `gulp test:unit`, a coverage report with coverages percentages is printed to the command line. It also generates an interactive HTML code coverage report in `test/unit_test_coverage`.
 
 ![lcov report](http://i.imgur.com/oJYfZCN.png)
 
@@ -35,4 +35,4 @@ Integration tests test the points at which your front-end JavaScript communicate
 
 When building browser-based applications, systems tests are browser (otherwise known as GUI) tests. They verify that the front-end code operates as expected in environments similar to the end-users'. They are slow and expensive to write and maintain. They break easily when the GUI is modified. But they are an incredibly important method of ensuring your application is operating correctly.
 
-They are often written in languages that can be understood by non-developers, traditionally business analysts. The cfgov-refresh (consumerfinance.gov) project uses [Protractor](https://www.protractortest.org) and [Cucumber](https://github.com/cucumber/cucumber-js) to execute [feature files](https://github.com/cfpb/cfgov-refresh/tree/master/test/browser_tests/cucumber/features/suites/default) that verify pages are working as expected.
+They are often written in languages that can be understood by non-developers, traditionally business analysts. The consumerfinance.gov (consumerfinance.gov) project uses [Protractor](https://www.protractortest.org) and [Cucumber](https://github.com/cucumber/cucumber-js) to execute [feature files](https://github.com/cfpb/consumerfinance.gov/tree/master/test/browser_tests/cucumber/features/suites/default) that verify pages are working as expected.

--- a/guides/installing-python.md
+++ b/guides/installing-python.md
@@ -161,12 +161,12 @@ If you already have created a virtual environment in the past (and it's running)
 
 ```shell
 deactivate
-rmvirtualenv cfgov-refresh
+rmvirtualenv consumerfinance.gov
 ```
 
 If Python 3.6 is already set up as the local Python (which it should be if you followed steps above, check by running `pyenv versions`):
 ```shell
-mkvirtualenv cfgov-refresh
+mkvirtualenv consumerfinance.gov
 ```
 
 If Python 3.6 isn't set as the local Python, you need to specify when you create the virtual environment:

--- a/guides/tracking-django-wagtail.md
+++ b/guides/tracking-django-wagtail.md
@@ -16,7 +16,7 @@
 
 We have two general types of Python projects:
 
-- The running [consumerfinance.gov](https://github.com/cfpb/cfgov-refresh) website
+- The running [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov) website
 - Satellite applications of consumerfinance.gov that live in their own repository, e.g., our satellite apps of consumerfinance.gov, like [ccdb5-ui](https://github.com/cfpb/ccdb5-ui)
 - Libraries that provide some functionality independent of consumerfinance.gov, e.g., [wagtail-sharing](https://github.com/cfpb/wagtail-sharing)
 
@@ -111,7 +111,7 @@ New releases of satellite apps should be automatically added to their GitHub rel
 
 ### Ensure consumerfinance.gov supports required versions
 
-consumerfinance.gov's [tox.ini](https://github.com/cfpb/cfgov-refresh/blob/master/tox.ini) matrixes on "current" vs "future" versions rather than on specific version numbers, and unlike our satellite apps and libraries pins its dependencies to specific versions. This can create incompatibilities that we need to deal with.
+consumerfinance.gov's [tox.ini](https://github.com/cfpb/consumerfinance.gov/blob/master/tox.ini) matrixes on "current" vs "future" versions rather than on specific version numbers, and unlike our satellite apps and libraries pins its dependencies to specific versions. This can create incompatibilities that we need to deal with.
  
 1. Add support for the new version(s) to the `tox` `future-config` matrix configuration. 
 
@@ -126,7 +126,7 @@ consumerfinance.gov's [tox.ini](https://github.com/cfpb/cfgov-refresh/blob/maste
        beautifulsoup4>=4.8.2
    ```
 
-2. Pin any new releases of satellite apps or libraries in the [requirements](https://github.com/cfpb/cfgov-refresh/blob/master/requirements/libraries.txt) file.
+2. Pin any new releases of satellite apps or libraries in the [requirements](https://github.com/cfpb/consumerfinance.gov/blob/master/requirements/libraries.txt) file.
 3. Consult release notes of the version(s) being added and make necessary code changes 
 4. Fix any tests that break as a result
 5. Ensure that running functionality works as expected
@@ -136,5 +136,5 @@ consumerfinance.gov's [tox.ini](https://github.com/cfpb/cfgov-refresh/blob/maste
 
 When we have a new LTS version of Django, or when there's a new release of Wagtail to deploy, the process of upgrading consumerfinance.gov should be simple, because we already have been tracking support for those versions.
 
-1. Pin [Django](https://github.com/cfpb/cfgov-refresh/blob/master/requirements/django.txt) and [Wagtail](https://github.com/cfpb/cfgov-refresh/blob/master/requirements/wagtail.txt) in their respective requirements files.
-2. Update the pins of any libraries that we pinned in the tox `future-config` `deps` in the [libraries](https://github.com/cfpb/cfgov-refresh/blob/master/requirements/libraries.txt) requirements file.
+1. Pin [Django](https://github.com/cfpb/consumerfinance.gov/blob/master/requirements/django.txt) and [Wagtail](https://github.com/cfpb/consumerfinance.gov/blob/master/requirements/wagtail.txt) in their respective requirements files.
+2. Update the pins of any libraries that we pinned in the tox `future-config` `deps` in the [libraries](https://github.com/cfpb/consumerfinance.gov/blob/master/requirements/libraries.txt) requirements file.

--- a/guides/unittesting-django-wagtail.md
+++ b/guides/unittesting-django-wagtail.md
@@ -36,7 +36,7 @@
 
 ### Choosing a `TestCase` base class
 
-When writing unit tests for code in cfgov-refresh there are multiple possible test case base classes that can be used.
+When writing unit tests for code in consumerfinance.gov there are multiple possible test case base classes that can be used.
 
 - [`unittest.TestCase`](https://docs.python.org/3.6/library/unittest.html#unittest.TestCase): For testing Python code that does not interact with Django or Wagtail. This class provides all the base Python unit test assertions, such as:
 
@@ -83,7 +83,7 @@ There are a few different ways to provide data for your tests to operate on.
 
 - Using [Django test fixtures](https://docs.djangoproject.com/en/1.11/topics/testing/tools/#fixture-loading) to load specific data into the database.
 
-    Generally we use Django test fixtures when we need to test a fairly large amount of data with fixed values that matter to multiple tests. For example, when [testing the interactive regulations search indexes](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/regulations3k/tests/test_search_indexes.py#L16).
+    Generally we use Django test fixtures when we need to test a fairly large amount of data with fixed values that matter to multiple tests. For example, when [testing the interactive regulations search indexes](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/regulations3k/tests/test_search_indexes.py#L16).
 
     ```python
     class RegulationIndexTestCase(TestCase):
@@ -103,7 +103,7 @@ There are a few different ways to provide data for your tests to operate on.
 
 - Using [Model Mommy](https://model-mommy.readthedocs.io/en/latest/index.html) to create test data automatically in code.
 
-    Generally use use Model Mommy when we need to test operations on a model whose values are unimportant to the outcome. Occasionlly we will pass specific values to Model Mommy when those values are important to the tests. An example is when [testing operations around image models and the way they're handled](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/test_meta_image.py#L14), when we want to make sure that the model gets rendered correctly.
+    Generally use use Model Mommy when we need to test operations on a model whose values are unimportant to the outcome. Occasionlly we will pass specific values to Model Mommy when those values are important to the tests. An example is when [testing operations around image models and the way they're handled](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/v1/tests/test_meta_image.py#L14), when we want to make sure that the model gets rendered correctly.
 
     ```python
     class TestMetaImage(TestCase):
@@ -201,7 +201,7 @@ There are other potential uses of Mock, but generally we prefer to test our code
 
 #### Mocking Requests with Responses
 
-For mocking HTTP calls that are made via [the Requests library](http://docs.python-requests.org/en/master/), we prefer the use of [Responses](https://github.com/getsentry/responses). For example, to test whether an informative banner is displayed to users [the ComplaintLandingView tests](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/legacy/tests/views/test_complaint.py#L67) use responses to provide response data for calls to `requests.get()`:
+For mocking HTTP calls that are made via [the Requests library](http://docs.python-requests.org/en/master/), we prefer the use of [Responses](https://github.com/getsentry/responses). For example, to test whether an informative banner is displayed to users [the ComplaintLandingView tests](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/legacy/tests/views/test_complaint.py#L67) use responses to provide response data for calls to `requests.get()`:
 
 ```python
 from django.test import TestCase
@@ -222,7 +222,7 @@ class ComplaintLandingViewTests(TestCase):
 
 #### Mocking boto with moto
 
-When we need to mock AWS services that are called via [boto](https://github.com/boto/boto/) we use the [moto](https://github.com/spulec/moto) library. For example, [to test our S3 utilities](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/test_s3utils.py#L21-L25), we initialize moto in our test case's `setUp` method:
+When we need to mock AWS services that are called via [boto](https://github.com/boto/boto/) we use the [moto](https://github.com/spulec/moto) library. For example, [to test our S3 utilities](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/v1/tests/test_s3utils.py#L21-L25), we initialize moto in our test case's `setUp` method:
 
 ```python
 class S3UtilsTestCase(TestCase):
@@ -239,7 +239,7 @@ From there calls to boto's S3 API will use the moto mock S3.
 
 To run Django and Wagtail unit tests we prefer to use [tox](https://tox.readthedocs.io/en/latest/). tox creates and manages virtual environments for running tests against multiple versions of dependencies.
 
-CFPB has a [sample `tox.ini`](https://github.com/cfpb/development/blob/master/tox.ini) that will test against Django 1.11 and 2.1 and Python 3.6. Additionally, running the tests for [CFPB's cfgov-refresh Django project are documented with that project](https://cfpb.github.io/cfgov-refresh/testing-be/).
+CFPB has a [sample `tox.ini`](https://github.com/cfpb/development/blob/master/tox.ini) that will test against Django 1.11 and 2.1 and Python 3.6. Additionally, running the tests for [CFPB's consumerfinance.gov Django project are documented with that project](https://cfpb.github.io/consumerfinance.gov/testing-be/).
 
 
 ## Common test patterns
@@ -248,7 +248,7 @@ CFPB has a [sample `tox.ini`](https://github.com/cfpb/development/blob/master/to
 
 Any custom method or properties on Django models should be unit tested.  We generally use `django.test.TestCase` as the base class because testing models is going to involve creating them in the test database.
 
-For example, interactive regulations `Part` objects [construct a full CFR title string from their fields](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/regulations3k/models/django.py#L58-L61):
+For example, interactive regulations `Part` objects [construct a full CFR title string from their fields](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/regulations3k/models/django.py#L58-L61):
 
 ```python
 class Part(models.Model):
@@ -263,7 +263,7 @@ class Part(models.Model):
         )
 ```
 
-This property [can be tested](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/regulations3k/tests/test_models.py#L196-L203) against a [Model Mommy-created model](#providing-test-data):
+This property [can be tested](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/regulations3k/tests/test_models.py#L196-L203) against a [Model Mommy-created model](#providing-test-data):
 
 ```python
 from django.test import TestCase
@@ -294,7 +294,7 @@ Testing Django views requires responding to a `request` object. Django provides 
 
     *Note*: Requests made with `django.test.Client` include all Django request handling, including middleware. See [overriding settings](#overriding-settings) if this is a problem.
 
-    The mortgage performance tests use a [combination of fixtures and Model Mommy-created models](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/data_research/tests/test_views.py#L47-L148) to set up for testing the timeseries view's response code and response data:
+    The mortgage performance tests use a [combination of fixtures and Model Mommy-created models](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/data_research/tests/test_views.py#L47-L148) to set up for testing the timeseries view's response code and response data:
 
     ```python
     from django.test import TestCase
@@ -318,7 +318,7 @@ Testing Django views requires responding to a `request` object. Django provides 
 
     Using a `RequestFactory` generated request is useful when you wish to call the view function or class directly, without going through Django's URL dispatcher or any middleware.
 
-    The Data & Research [conference registration handler tests](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/models/test_base.py#L21) use a `RequestFactory` to generate requests with various inputs, including how a `GET` parameter is handled:
+    The Data & Research [conference registration handler tests](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/v1/tests/models/test_base.py#L21) use a `RequestFactory` to generate requests with various inputs, including how a `GET` parameter is handled:
 
     ```python
     from django.test import RequestFactory , TestCase
@@ -344,7 +344,7 @@ We generally do not recommend creating `django.http.HttpRequest` objects directl
 
 In general the same principle applies to Wagtail pages as to Django models: any custom method or properties should be unit tested.
 
-For example, the careers `JobListingPage` [overrides the default `get_context()` method](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jobmanager/models/pages.py#L140) to provide additional context when rendering the page.
+For example, the careers `JobListingPage` [overrides the default `get_context()` method](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/jobmanager/models/pages.py#L140) to provide additional context when rendering the page.
 
 ```python
 from django.test import TestCase, RequestFactory
@@ -398,7 +398,7 @@ class TestDateTimeBlock(SimpleTestCase):
 
 More complicated blocks' fields are stored as JSON on the page object. To prepare that JSON as the block's `value` to pass to the block's `render()` and other methods, the `block.to_python()` method is used.
 
-For example, the `TextIntroduction` block [requires its `heading` field when the `eyebrow` field is given](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/atomic_elements/molecules.py#L98-L105). This is tested by checking if a [`ValidationError` is raised in `block.clean(value)`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/atomic_elements/test_molecules.py#L250-L255). To prepare a value to pass, `to_python()` is used:
+For example, the `TextIntroduction` block [requires its `heading` field when the `eyebrow` field is given](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/v1/atomic_elements/molecules.py#L98-L105). This is tested by checking if a [`ValidationError` is raised in `block.clean(value)`](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/v1/tests/atomic_elements/test_molecules.py#L250-L255). To prepare a value to pass, `to_python()` is used:
 
 ```python
 from django.test import SimpleTestCase
@@ -444,7 +444,7 @@ We generally recommend using `WagtailTestUtils` to login and test the admin unle
 
 When testing custom management commands [Django provides a `call_command()` function](https://docs.djangoproject.com/en/2.1/topics/testing/tools/#management-commands) which will call the command direct the output into a `StringIO` object to be introspected.
 
-For example, our [custom makemessages command (that adds support for Jinja2 templates)](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/management/commands/makemessages.py) is tested [using `call_command()`](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/tests/management/commands/test_makemessages.py#L66) (although it inspects the resulting `.po` file):
+For example, our [custom makemessages command (that adds support for Jinja2 templates)](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/v1/management/commands/makemessages.py) is tested [using `call_command()`](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/v1/tests/management/commands/test_makemessages.py#L66) (although it inspects the resulting `.po` file):
 
 ```python
 from django.core.management import call_command
@@ -467,7 +467,7 @@ We use [Django-Flags](https://cfpb.github.io/django-flags/) to feature flag code
 
 In all cases, the easiest way to test with explicit flag states is to [override the `FLAGS` setting](#overriding-settings) and include only your specific flag with a `boolean` condition of `True`.
 
-For example, to test [a function that serves a URL via Wagtail depending on the state of a flag](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/urls.py#L42-L53), the base URL tests [check behavior with a flag explicitly enabled and again with that flag explicitly disabled](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/cfgov/tests/test_urls.py#L92-L109):
+For example, to test [a function that serves a URL via Wagtail depending on the state of a flag](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/cfgov/urls.py#L42-L53), the base URL tests [check behavior with a flag explicitly enabled and again with that flag explicitly disabled](https://github.com/cfpb/consumerfinance.gov/blob/master/cfgov/cfgov/tests/test_urls.py#L92-L109):
 
 ```python
 class FlaggedWagtailOnlyViewTests(TestCase):

--- a/standards/css.md
+++ b/standards/css.md
@@ -191,7 +191,7 @@ If you find yourself going further, think about re-organizing your rules _(eithe
 
 ### Variables
 
-- Colors: (use generic variable names like recent cfgov-refresh update)
+- Colors: (use generic variable names like recent consumerfinance.gov update)
 - Breakpoints: standard variable names for commonly used breakpoints
 
 ### Comments

--- a/standards/python.md
+++ b/standards/python.md
@@ -38,7 +38,7 @@ We use [isort](https://github.com/timothycrosley/isort) to lint imports to compl
 
 - Multiple-line `from` imports become grouped within parenthesis with one imported name per-line and a trailing comma for the last imported name.
 - Django imports are included as their own section between the standard library and third-party imports.
-- For Wagtail-specific projects like [cfgov-refresh](https://github.com/cfpb/cfgov-refresh), Wagtail imports are included as their own section between Django and third-party imports.
+- For Wagtail-specific projects like [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov), Wagtail imports are included as their own section between Django and third-party imports.
 
 The isort configuration can go into a `tox.ini` file under an `[isort]` header.
 
@@ -58,6 +58,6 @@ The difference between pinned versions of dependencies in `requirements.txt`  an
 
 [Donald Stufft has an excelent article with a more in-depth discussion of this difference](https://caremad.io/posts/2013/07/setup-vs-requirement/). For our purposes, we use both requirements files and requirements specified in `setup.py` depending on the circumstance of the dependency.
 
-Our applications should use requirements files with pinned versions. For example, [cfgov-refresh has several requirements files](https://github.com/cfpb/cfgov-refresh/tree/master/requirements) that pin all relevant versions for deployment, testing, local execution, and other specific needs. Some of these requirements files inherit from each other (e.g., [`base.txt` uses the `-r libraries.txt` directive](https://github.com/cfpb/cfgov-refresh/blob/master/requirements/base.txt#L3) to include the requirements from that file).
+Our applications should use requirements files with pinned versions. For example, [consumerfinance.gov has several requirements files](https://github.com/cfpb/consumerfinance.gov/tree/master/requirements) that pin all relevant versions for deployment, testing, local execution, and other specific needs. Some of these requirements files inherit from each other (e.g., [`base.txt` uses the `-r libraries.txt` directive](https://github.com/cfpb/consumerfinance.gov/blob/master/requirements/base.txt#L3) to include the requirements from that file).
 
 Our libraries should specify dependencies with supported version ranges ([and those ranges should be tested with tox](../tox.ini)) in `setup.py` using [the appropriate setuptools `_requires` keyword](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies). For example, our [wagtail-sharing library](https://github.com/cfpb/wagtail-sharing) declares install-time requirements with `install_requires` and testing requirements with `extras_require={'testing': testing_extras}`.


### PR DESCRIPTION
This change updates our docs to point to github.com/cfpb/consumerfinance.gov instead of ot github.com/cfpb/cfgov-refresh.
